### PR TITLE
RDKB-62997 RDKB-62998: [GitHub Coverity] Enable Coverity Scan for mtu-modifier using Native Build Integration

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -1,0 +1,36 @@
+name: Build mtu-modifier Component in Native Environment
+
+on:
+  push:
+    branches: [ main, 'sprint/**', 'release/**', develop ]
+  pull_request:
+    branches: [ main, 'sprint/**', 'release/**', topic/RDK*, develop ]
+
+jobs:
+  build-mtu-modifier-on-pr:
+    name: Build mtu-modifier component in github rdkcentral
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rdkcentral/docker-rdk-ci:latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: native build
+        run: |
+          #Trust the workspace
+          git config --global --add safe.directory '*'
+
+          # Pull the latest changes for the native build system
+          git submodule update --init --recursive --remote
+
+          # Build and install dependencies
+          chmod +x build_tools_workflows/cov_docker_script/setup_dependencies.sh
+          ./build_tools_workflows/cov_docker_script/setup_dependencies.sh ./cov_docker_script/component_config.json
+
+          # Build component
+          chmod +x build_tools_workflows/cov_docker_script/build_native.sh
+          ./build_tools_workflows/cov_docker_script/build_native.sh ./cov_docker_script/component_config.json "$(pwd)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.RDKCM_RDKE }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "build_tools_workflows"]
+	path = build_tools_workflows
+	url = https://github.com/rdkcentral/build_tools_workflows
+	branch = develop

--- a/cov_docker_script/README.md
+++ b/cov_docker_script/README.md
@@ -1,0 +1,3 @@
+# 🔧 Coverity Native Build System for RDK-B Components
+
+The documentation and source for the RDK-B native build system has been centralized in [rdkcentral/build_tools_workflows](https://github.com/rdkcentral/build_tools_workflows/blob/develop/cov_docker_script/README.md)

--- a/cov_docker_script/component_config.json
+++ b/cov_docker_script/component_config.json
@@ -1,0 +1,37 @@
+{
+  "_comment": "Component Build Configuration for Coverity/Native Builds",
+  "_version": "2.0",
+  "_description": "Defines dependencies and build settings for the mtu-modifier kernel module",
+  
+"dependencies": {
+    "_comment": "External repositories needed by this component",
+    "repos": [
+      {
+        "name": "linux-kernel",
+        "repo": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+        "branch": "v5.15.202",
+        "clone_depth": 1,
+        "build": {
+          "type": "commands",
+          "commands": [
+            "make defconfig",
+            "make modules_prepare"
+          ]
+        }
+      }
+    ]
+  },
+  
+  "native_component": {
+    "_comment": "Configuration for the main component being built",
+    "name": "mtu-modifier",
+    "include_path": "",
+    "lib_output_path": "",
+    "build": {
+        "type": "commands",
+        "commands": [
+          "make KERNEL_SRC=$HOME/build/linux-kernel"
+        ]
+    }
+  }
+}


### PR DESCRIPTION
Reason for change: Enable coverity scan using native build.
Test Procedure: All the checks should pass in github
Risks: Low
Priority: P1
Signed-off-by: sowmiya_chelliah@comcast.com 